### PR TITLE
API-410: fix API catalog with missing jobs

### DIFF
--- a/master/community/api/fixtures/jobs.yml
+++ b/master/community/api/fixtures/jobs.yml
@@ -524,3 +524,8 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             filePath:   /tmp/products_export_grid_context_%locale%_%scope%.xlsx
+    compute_product_models_descendants:
+        connector: internal
+        alias:     compute_product_models_descendants
+        label:     Compute product models descendants
+        type:      compute_product_models_descendants


### PR DESCRIPTION
Adding a missing job in the API catalog