### PR TITLE
API-417: Add missing compute jobs to API catalogs

### DIFF
--- a/2.0/community/api/fixtures/jobs.yml
+++ b/2.0/community/api/fixtures/jobs.yml
@@ -297,6 +297,21 @@ jobs:
         alias:     set_attribute_requirements
         label:     Set family attribute requirements
         type:      mass_edit
+    compute_product_models_descendants:
+        connector: internal
+        alias:     compute_product_models_descendants
+        label:     Compute product models descendants
+        type:      compute_product_models_descendants
+    compute_completeness_of_products_family:
+        connector: internal
+        alias:     compute_completeness_of_products_family
+        label:     compute completeness of products family
+        type:      compute_completeness_of_products_family
+    compute_family_variant_structure_changes:
+        connector: internal
+        alias:     compute_family_variant_structure_changes
+        label:     Compute variant structure changes
+        type:      compute_family_variant_structure_changes
     csv_product_quick_export:
         connector: Akeneo CSV Connector
         alias: csv_product_quick_export

--- a/2.0/enterprise/api/fixtures/jobs.yml
+++ b/2.0/enterprise/api/fixtures/jobs.yml
@@ -488,6 +488,21 @@ jobs:
         alias:     set_attribute_requirements
         label:     Set family attribute requirements
         type:      mass_edit
+    compute_product_models_descendants:
+        connector: internal
+        alias:     compute_product_models_descendants
+        label:     Compute product models descendants
+        type:      compute_product_models_descendants
+    compute_completeness_of_products_family:
+        connector: internal
+        alias:     compute_completeness_of_products_family
+        label:     compute completeness of products family
+        type:      compute_completeness_of_products_family
+    compute_family_variant_structure_changes:
+        connector: internal
+        alias:     compute_family_variant_structure_changes
+        label:     Compute variant structure changes
+        type:      compute_family_variant_structure_changes
 
     csv_product_quick_export:
         connector: Akeneo CSV Connector

--- a/master/community/api/fixtures/jobs.yml
+++ b/master/community/api/fixtures/jobs.yml
@@ -297,6 +297,21 @@ jobs:
         alias:     set_attribute_requirements
         label:     Set family attribute requirements
         type:      mass_edit
+    compute_product_models_descendants:
+        connector: internal
+        alias:     compute_product_models_descendants
+        label:     Compute product models descendants
+        type:      compute_product_models_descendants
+    compute_completeness_of_products_family:
+        connector: internal
+        alias:     compute_completeness_of_products_family
+        label:     compute completeness of products family
+        type:      compute_completeness_of_products_family
+    compute_family_variant_structure_changes:
+        connector: internal
+        alias:     compute_family_variant_structure_changes
+        label:     Compute variant structure changes
+        type:      compute_family_variant_structure_changes
     csv_product_quick_export:
         connector: Akeneo CSV Connector
         alias: csv_product_quick_export

--- a/master/enterprise/api/fixtures/jobs.yml
+++ b/master/enterprise/api/fixtures/jobs.yml
@@ -488,6 +488,21 @@ jobs:
         alias:     set_attribute_requirements
         label:     Set family attribute requirements
         type:      mass_edit
+    compute_product_models_descendants:
+        connector: internal
+        alias:     compute_product_models_descendants
+        label:     Compute product models descendants
+        type:      compute_product_models_descendants
+    compute_completeness_of_products_family:
+        connector: internal
+        alias:     compute_completeness_of_products_family
+        label:     compute completeness of products family
+        type:      compute_completeness_of_products_family
+    compute_family_variant_structure_changes:
+        connector: internal
+        alias:     compute_family_variant_structure_changes
+        label:     Compute variant structure changes
+        type:      compute_family_variant_structure_changes
 
     csv_product_quick_export:
         connector: Akeneo CSV Connector


### PR DESCRIPTION
Add some new jobs that were recently introduced in Akeneo 2.0.x:
- compute_product_models_descendants: 
- compute_completeness_of_products_family
- compute_family_variant_structure_changes